### PR TITLE
memory management and symbol export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
 MODULE_big = decoder_json
 OBJS = decoder_json.o
 JANSSON_VERSION = 2.7
-SHLIB_LINK = ./jansson-${JANSSON_VERSION}/build/lib/libjansson.a
+SHLIB_LINK = -Wl,--version-script,visibility.map ./jansson-${JANSSON_VERSION}/build/lib/libjansson.a
 PG_CPPFLAGS =  -I./jansson-${JANSSON_VERSION}/build/include
 REGRESS = default
 

--- a/decoder_json.c
+++ b/decoder_json.c
@@ -32,6 +32,7 @@
 #include "utils/syscache.h"
 #include "utils/typcache.h"
 #include "utils/array.h"
+#include <assert.h>
 #include <jansson.h>
 
 PG_MODULE_MAGIC;
@@ -98,7 +99,9 @@ decoder_json_startup(LogicalDecodingContext *ctx,
     ListCell   *option;
     DecoderRawData *data;
 
+    json_set_alloc_funcs(palloc,pfree);
     data = palloc(sizeof(DecoderRawData));
+    assert(data);
     data->context = AllocSetContextCreate(ctx->context,
                                           "Raw decoder context",
                                           ALLOCSET_DEFAULT_MINSIZE,
@@ -334,6 +337,7 @@ static Pair
         return NULL;
 
     pair = palloc(sizeof(Pair));
+    assert(pair);
     pair->value = val;
     pair->name = attname;
     return pair;
@@ -451,7 +455,7 @@ write_struct(StringInfo s,
     elog(LOG, "Struct:%s", result);
 
     appendStringInfoString(s, result);
-    free(result);
+    pfree(result);
 }
 
 /*

--- a/visibility.map
+++ b/visibility.map
@@ -1,0 +1,5 @@
+PG
+{
+	global: Pg_magic_func; _PG_output_plugin_init;
+	local: *;
+};


### PR DESCRIPTION
We made a few changes to improve the robustness of the json_decoder in a production environment. In particular, it only exports the bare minimum of symbols now so it doesn't clash with other libraries and extensions.
